### PR TITLE
Fixed public and private issues of friends history mood

### DIFF
--- a/code/app/src/main/java/com/example/unemployedavengers/friendSection/FriendsHistory.java
+++ b/code/app/src/main/java/com/example/unemployedavengers/friendSection/FriendsHistory.java
@@ -188,7 +188,7 @@ public class FriendsHistory extends Fragment {
 
         friendsAdapter.notifyDataSetChanged();
 
-        // Set click listener to view friend's mood events
+        // Set click listener to view only the selected friend's mood events
         binding.friendsHistoryList.setOnItemClickListener((parent, view, position, id) -> {
             User selectedUser = followedUsers.get(position);
 
@@ -196,6 +196,8 @@ public class FriendsHistory extends Fragment {
             Bundle bundle = new Bundle();
             bundle.putString("followedUserId", selectedUser.getUserId());
             bundle.putString("followedUsername", selectedUser.getUsername());
+            // Add a flag to indicate we want to see only this user's moods
+            bundle.putBoolean("singleUserView", true);
 
             // Navigate to the followed user's mood events fragment
             Navigation.findNavController(view)


### PR DESCRIPTION
I fixed two issues with the mood history feature: 1) implemented privacy filtering to ensure friends can only see public moods, not private ones, and 2) modified the navigation to show only a specific friend's moods when their name is clicked, rather than showing all friends moods.